### PR TITLE
Remove redundant comment from import statement

### DIFF
--- a/Frontend/src/pages/admin/orders.jsx
+++ b/Frontend/src/pages/admin/orders.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { useNavigate } from "react-router-dom"; // ✅ ADDED
+import { useNavigate } from "react-router-dom";
 import api from "../../api/axios";
 import { Download} from "lucide-react";
 import {


### PR DESCRIPTION
Cleaned up the import of useNavigate from react-router-dom by removing an unnecessary comment.